### PR TITLE
Meta Corruption Resiliency and General Fixes

### DIFF
--- a/erasureLib/erasure.c
+++ b/erasureLib/erasure.c
@@ -3547,7 +3547,7 @@ int ne_rebuild1_vl( SnprintfFunc fn, void* state,
          PRINTdbg( "reading %zd bytes from original file\n", buff_size );
          off_t bytes_read = ne_read( read_handle, NULL, buff_size, bytes_repaired );
          // check for an under-read
-         if ( bytes_read < buff_size ) {
+         if ( bytes_read < (off_t)buff_size ) { // the off_t cast is needed to ensure bytes_read is not autocast to an unsigned value
             if( bytes_read < 0 ) {
                PRINTerr( "ne_rebuild: failed to read %zd bytes at offset %zd from the original stripe\n", buff_size, bytes_repaired );
                err_out = 1;

--- a/erasureLib/erasure.c
+++ b/erasureLib/erasure.c
@@ -568,7 +568,7 @@ void *bq_writer(void *arg) {
     }
 
     if((bq->qdepth == 0) && (bq->con_flags & BQ_FINISHED)) {       // then we are done.
-      PRINTdbg("BQ finished\n");
+      PRINTdbg("BQ_writer completed all work for block %d\n", bq->block_number);
       pthread_mutex_unlock(&bq->qlock);
       break;
     }

--- a/erasureLib/erasure.c
+++ b/erasureLib/erasure.c
@@ -3893,6 +3893,7 @@ int ne_stat1( SnprintfFunc fn, void* state,
                PRINTdbg( "setting N/E to %d/%d after locating %d matching values\n", read_meta_state.N, read_meta_state.E, matches );
                handle->erasure_state->N = read_meta_state.N;
                handle->erasure_state->E = read_meta_state.E;
+               num_blocks = read_meta_state.N + read_meta_state.E;
             }
             else {
                // if we are still within our bounds, just keep extending the stripe, trying to find *something*
@@ -3900,16 +3901,14 @@ int ne_stat1( SnprintfFunc fn, void* state,
                   num_blocks++;
                }
                else {
+                  // otherwise, ENOENT is probably the most applicable failure condition
                   error = 1; // to trigger cleanup below
                   errno = ENOENT;
                }
-               continue;
             }
-
-            num_blocks = read_meta_state.N + read_meta_state.E;
-         }
-      }
-   }
+         } // END OF : if ( (i+1) >= MIN_MD_CONSENSUS )
+      } // END OF : if ( handle->erasure_state->N == 0 )
+   } // END OF : for(i = 0; i < num_blocks; i++)
 
    // in some rare cases (N=1 and E=0 for example), we may have started too many threads
    // terminate those now

--- a/erasureLib/erasure.c
+++ b/erasureLib/erasure.c
@@ -2179,10 +2179,12 @@ ssize_t ne_read( ne_handle handle, void *buffer, size_t nbytes, off_t offset ) {
          if ( cur_block >= skip_blocks  &&  cur_block < N ) {
             // if so, copy it to our output buffer
             size_t to_copy = ( (bsz - offset) > nbytes ) ? nbytes : (bsz - offset);
-            // as no one but ne_read should be adjusting the head position, and we have already verified that this buffer is ready, 
-            // we can safely copy from it without holding the queue lock
-            PRINTdbg( "copying %zd bytes from thread %d's buffer at position %d to the output buff\n", to_copy, cur_block, bq->head );
-            memcpy( buffer + bytes_read, bq->buffers[bq->head] + offset, to_copy );
+            if ( buffer ) { // only actually copy out the data if we have a valid buffer
+               // as no one but ne_read should be adjusting the head position, and we have already verified that this buffer is ready, 
+               // we can safely copy from it without holding the queue lock
+               PRINTdbg( "copying %zd bytes from thread %d's buffer at position %d to the output buff\n", to_copy, cur_block, bq->head );
+               memcpy( buffer + bytes_read, bq->buffers[bq->head] + offset, to_copy );
+            }
             nbytes -= to_copy;
             bytes_read += to_copy;
             offset = 0; // as we have copied from the first applicable value, this offset is no longer relevant

--- a/erasureLib/erasure.h
+++ b/erasureLib/erasure.h
@@ -292,8 +292,7 @@ typedef enum {
 
 typedef enum {
   BQ_OPEN     = 0x01 << 0, // indicates that this thread has successfully opened its data file
-  BQ_HALTED   = 0x01 << 1, // indicates that this thread is 'paused'
-  BQ_SKIP     = 0x01 << 2  // indicates that this thread is skipping all work assigned to it
+  BQ_HALTED   = 0x01 << 1  // indicates that this thread is 'paused'
 } BQ_State_Flags;
 
 

--- a/erasureLib/erasure.h
+++ b/erasureLib/erasure.h
@@ -169,7 +169,7 @@ GNU licenses can be found at http://www.gnu.org/licenses/.
 #  define ec_encode_data(...) ec_encode_data_base(__VA_ARGS__)
 #endif
 
-#define UNSAFE(HANDLE, NERR) (NERR > ((HANDLE)->erasure_state->E - MIN_PROTECTION))
+#define UNSAFE(HANDLE, NERR) ( (NERR)  &&  (NERR > ((HANDLE)->erasure_state->E - MIN_PROTECTION)) )
 
 typedef uint32_t u32;
 typedef uint64_t u64;

--- a/erasureLib/erasureTest
+++ b/erasureLib/erasureTest
@@ -358,6 +358,8 @@ while [[ $cnt -lt $ITER ]]; do
             if [[ $? -eq 2 ]]; then
                (( silent_met_err_cnt++ ))
                silent_met_err_list[$errpos]=1
+            else
+               dstat=$(( dstat + 2**errpos ))
             fi
          fi
       done
@@ -393,12 +395,6 @@ while [[ $cnt -lt $ITER ]]; do
                fi
             done
             echo "RELOCATING ERROR TO POSTION $errpos"
-            silent_met_err_list[$errpos]=0
-            (( silent_met_err_cnt-- ))
-         elif [[ ${silent_met_err_list[$errpos]} -ne 0 ]]; then
-            # if we'er corrupting a block with silent meta corruption, we don't need to worry about that location any more
-            silent_met_err_list[$errpos]=0
-            (( silent_met_err_cnt-- ))
          fi
          if [[ ${dat_err_list[$errpos]} -eq 0 ]]; then
             # only corrupt the file if we are hitting a new postion
@@ -421,11 +417,18 @@ while [[ $cnt -lt $ITER ]]; do
             fi
             # only note errors which do not align with meta errors and which are removal type or in data blocks
             if [[ $cor_type -eq 0  ||  $truepos -lt $n ]]; then
-               dstat=$(( dstat + 2**errpos ))
-               if [[ ${met_err_list[$errpos]} -eq 0 ]]; then
+               if [[ ${met_err_list[$errpos]} -eq 0  ]]; then
                   tstat=$(( tstat + 2**errpos ))
+                  dstat=$(( dstat + 2**errpos ))
+               elif [[ ${silent_met_err_list[$errpos]} -ne 0 ]]; then
+                  dstat=$(( dstat + 2**errpos ))
                fi
             fi
+         fi
+         if [[ ${silent_met_err_list[$errpos]} -ne 0 ]]; then
+            # if we'er corrupting a block with silent meta corruption, we don't need to worry about that location any more
+            silent_met_err_list[$errpos]=0
+            (( silent_met_err_cnt-- ))
          fi
       done
 

--- a/erasureLib/erasureTest
+++ b/erasureLib/erasureTest
@@ -727,7 +727,7 @@ if [[ $BC -eq 0 ]]; then
 
    if [[ $count -ne 0 ]]; then
       tcnt=$( echo "$tcnt ) / $count" | bc -l )
-      output="$output\nStatus:,Performed = $count,AvgTime = $tcnt Seconds"
+      output="$output\nVerify:,Performed = $count,AvgTime = $tcnt Seconds"
    fi
 
    { res=$( printf "$output\n" | column -s "," -o "   " -t ); } 2>/dev/null

--- a/erasureLib/erasureTest
+++ b/erasureLib/erasureTest
@@ -115,9 +115,19 @@ fi
 # corruption insertion function
 corrupt_file() {
    ftocorr="$1"
+   secondary_backup="$2"
    echo "   Corrupting file \"$ftocorr\"..."
    echo "      creating backup of $ftocorr"
    cp $ftocorr "$ftocorr".backup
+
+   extra_backup="$ftocorr".meta
+   if [[ "$ftocorr" =~ .meta$ ]]; then
+      extra_backup=$( echo "$ftocorr" | sed 's/\.meta$//' )
+   fi
+   if [[ $secondary_backup -eq 1 ]]; then
+      echo "      creating a backup of $extra_backup"
+      cp "$extra_backup" "$extra_backup".backup
+   fi
 
    ctype=$(( RANDOM % (3-ICRC) ))
    if [[ $ctype -eq 0 ]]; then
@@ -259,8 +269,7 @@ while [[ $cnt -lt $ITER ]]; do
    start=$RANDOM
    let "start %= $(( n + e ))"
 
-   met_err_free=0
-   dat_err_free=0
+   err_free=0
 
    echo
    echo -e "\e[34mGenerating $n+$e striping starting at file $start...\e[0m"
@@ -280,7 +289,6 @@ while [[ $cnt -lt $ITER ]]; do
    echo "   stripe generation complete" >> $LOGFILE
    echo
    ls $( echo "$EPAT" | sed 's/%d/\*/' )
-   echo
 
    incnt=0
    while [[ $incnt -lt $INITER ]]; do
@@ -290,7 +298,6 @@ while [[ $cnt -lt $ITER ]]; do
          echo -e "\e[34mContinuing with the same $n+$e start position $start stripe...\e[0m"
          echo >> $LOGFILE
          echo "Continuring to use $n+$e striping with start $start..." >> $LOGFILE
-         echo
       fi
 
       met_err_list=( 0 )
@@ -301,25 +308,50 @@ while [[ $cnt -lt $ITER ]]; do
       tstat=0
       dstat=0
 
-      # Insert Meta Corruption
-      nerr=$RANDOM
-      let "nerr %= $(( e + 1 ))"
-      if [[ $nerr -eq 0 ]]; then
-         if [[ $met_err_free -eq 1 ]]; then
-            nerr=$e
+      # Determine error counts
+      nerr_met=0
+      nerr=0
+
+      while true; do
+         nerr_met=$RANDOM
+         let "nerr_met %= $(( e + 1 ))"
+         if [[ $nerr_met -eq $(( n + e - 1 )) ]]; then
+            # special case, we can't leave only a single valid meta file, as there is no guaratee we will get correct values then
+            nerr_met=$(( nerr_met - 1 ))
          fi
-         met_err_free=1
-      fi
-      if [[ $nerr -eq $(( n + e - 1 )) ]]; then
-         # special case, we can't leave only a single valid meta file, as there is no guaratee we will get correct values then
-         nerr=$(( nerr - 1 ))
-      fi
+    
+         nerr=$RANDOM
+         let "nerr %= $(( e + 1 ))"
+         if [[ $nerr -eq 0 ]]; then
+            if [[ $dat_err_free -eq 1 ]]; then
+               nerr=$e
+            fi
+            dat_err_free=1
+         fi
+
+         # only accept a stripe without errors if we have not already tried it
+         if [[ $nerr -ne 0  ||  $nerr_met -ne 0 ]]; then
+            break
+         elif [[ $err_free -eq 0 ]]; then
+            err_free=1
+            break
+         fi
+         echo "Re-randomizing error counts to avoid pristine stripe"
+      done
+      echo
+
+      # Insert Meta Corruption
       errcnt=0
 
-      echo "$nerr meta error(s) are to be inserted..."
-      echo "Inserting $nerr meta error(s)..." >> $LOGFILE
+      echo "$nerr_met meta error(s) are to be inserted..."
+      echo "Inserting $nerr_met meta error(s)..." >> $LOGFILE
 
-      while [[ $errcnt -lt $nerr ]]; do
+      # these are used to note locations with potential silent global crc errors
+      # we must make sure not to leave so many of these that the stripe becomes unrecoverable
+      silent_met_err_cnt=0
+      silent_met_err_list=( 0 )
+
+      while [[ $errcnt -lt $nerr_met ]]; do
          errpos=$RANDOM
          let "errpos %= $(( n + e ))"
          if [[ ${met_err_list[$errpos]} -eq 0 ]]; then
@@ -328,7 +360,11 @@ while [[ $cnt -lt $ITER ]]; do
             met_err_list[$errpos]=1
             stat=$(( stat + 2**errpos ))
             tstat=$(( tstat + 2**errpos ))
-            corrupt_file "$( echo "$EPAT" | sed 's/%d/'"$errpos"'/' | sed 's/$/.meta/' )"
+            corrupt_file "$( echo "$EPAT" | sed 's/%d/'"$errpos"'/' | sed 's/$/.meta/' )" 1
+            if [[ $? -eq 2 ]]; then
+               (( silent_met_err_cnt++ ))
+               silent_met_err_list[$errpos]=1
+            fi
          fi
       done
 
@@ -344,16 +380,8 @@ while [[ $cnt -lt $ITER ]]; do
       echo "Meta error insertion complete, pattern is : $npat"
       echo "Meta errors inserted, pattern is  $npat" >> $LOGFILE
 
- 
+
       # Insert Data Corruption
-      nerr=$RANDOM
-      let "nerr %= $(( e + 1 ))"
-      if [[ $nerr -eq 0 ]]; then
-         if [[ $dat_err_free -eq 1 ]]; then
-            nerr=$e
-         fi
-         dat_err_free=1
-      fi
       errcnt=0
 
       echo "$nerr data error(s) are to be inserted..."
@@ -362,6 +390,22 @@ while [[ $cnt -lt $ITER ]]; do
       while [[ $errcnt -lt $nerr ]]; do
          errpos=$RANDOM
          let "errpos %= $(( n + e ))"
+         # special checks to avoid the possiblity of a silent global crc error rendering the stripe unrecoverable
+         if [[ ${silent_met_err_list[$errpos]} -eq 0  &&  $(( 1 + errcnt + silent_met_err_cnt )) -gt $e ]]; then
+            echo "ERROR AT POSTION $errpos MAY RESULT IN UNRECOVERABLE STRIPE"
+            for errpos in $(seq 0 $(( n + e - 1 )) ); do
+               if [[ ${silent_met_err_list[$errpos]} -ne 0 ]]; then
+                  break;
+               fi
+            done
+            echo "RELOCATING ERROR TO POSTION $errpos"
+            silent_met_err_list[$errpos]=0
+            (( silent_met_err_cnt-- ))
+         elif [[ ${silent_met_err_list[$errpos]} -ne 0 ]]; then
+            # if we'er corrupting a block with silent meta corruption, we don't need to worry about that location any more
+            silent_met_err_list[$errpos]=0
+            (( silent_met_err_cnt-- ))
+         fi
          if [[ ${dat_err_list[$errpos]} -eq 0 ]]; then
             # only corrupt the file if we are hitting a new postion
             truepos=$(( errpos - start ))
@@ -370,13 +414,19 @@ while [[ $cnt -lt $ITER ]]; do
             fi
             errcnt=$(( errcnt + 1 ))
             dat_err_list[$errpos]=1
+            cor_type=0
             # if there are no previous errors at this postion, note it for rc checking
             if [[ ${met_err_list[$errpos]} -eq 0 ]]; then
                stat=$(( stat + 2**errpos ))
+               corrupt_file "$( echo "$EPAT" | sed 's/%d/'"$errpos"'/' )" 1
+               cor_type=$?
+            else
+               # make sure not to create a backup '.meta' file if we have already corrupted it
+               corrupt_file "$( echo "$EPAT" | sed 's/%d/'"$errpos"'/' )" 0
+               cor_type=$?
             fi
-            corrupt_file "$( echo "$EPAT" | sed 's/%d/'"$errpos"'/' )"
             # only note errors which do not align with meta errors and which are removal type or in data blocks
-            if [[ $? -eq 0  ||  $truepos -lt $n ]]; then
+            if [[ $cor_type -eq 0  ||  $truepos -lt $n ]]; then
                dstat=$(( dstat + 2**errpos ))
                if [[ ${met_err_list[$errpos]} -eq 0 ]]; then
                   tstat=$(( tstat + 2**errpos ))
@@ -540,37 +590,37 @@ while [[ $cnt -lt $ITER ]]; do
          echo "read completed"
          echo
 
-         if [[ $npat == *"1"* ]]; then
-            echo >> $LIBTLOG
-            echo -n "Attempting error recovery..."
-            echo "Attempting error recovery..." >> $LOGFILE
+         echo >> $LIBTLOG
+         echo -n "Attempting error recovery..."
+         echo "Attempting error recovery..." >> $LOGFILE
 
-            noinfo=$RANDOM
-            let "noinfo %= 2"
+         noinfo=$RANDOM
+         let "noinfo %= 2"
 
-            CMD="./libneTest rebuild $EPAT $n $e $start"
-            
-            if [[ $noinfo -eq 1 ]]; then
-               echo -n "ignoring stripe state for this rebuild..."
-               echo "   Using '-n' option to perform rebuild while ignoring stripe state..." >> $LOGFILE
-               CMD="./libneTest rebuild $EPAT -n"
-            fi
+         CMD="./libneTest rebuild $EPAT $n $e $start"
+         
+         if [[ $noinfo -eq 1 ]]; then
+            echo -n "ignoring stripe state for this rebuild..."
+            echo "   Using '-n' option to perform rebuild while ignoring stripe state..." >> $LOGFILE
+            CMD="./libneTest rebuild $EPAT -n"
+         fi
 
-            { ret=$( time -p $CMD 2>&1 | tee -a $LIBTLOG | tail -n 1 | awk '{print $NF}' ); } 2>>$TLOGPREF$$.recovery
+         { ret=$( time -p $CMD 2>&1 | tee -a $LIBTLOG | tail -n 1 | awk '{print $NF}' ); } 2>>$TLOGPREF$$.recovery
 
 
-            #if [[ ! $ret =~ $re  ||  $ret -ne $stat ]]; then
-            if [[ ! $ret =~ $re  ||  $ret -ne 0 ]]; then
-               echo
-               echo -e "\033[0;31mFAIL - ne_rebuild has failed, expected return of 0 but received $ret"
-               echo -e "CMD = $CMD\033[0m"
-               echo "   FAILURE: an error occured within ne_rebuild, expected return of 0 but received $ret" >> $LOGFILE
-               echo "CMD = $CMD" >> $LOGFILE
-               exit $ret
-            fi
-            echo "rebuild completed"
+         #if [[ ! $ret =~ $re  ||  $ret -ne $stat ]]; then
+         if [[ ! $ret =~ $re  ||  $ret -ne 0 ]]; then
             echo
+            echo -e "\033[0;31mFAIL - ne_rebuild has failed, expected return of 0 but received $ret"
+            echo -e "CMD = $CMD\033[0m"
+            echo "   FAILURE: an error occured within ne_rebuild, expected return of 0 but received $ret" >> $LOGFILE
+            echo "CMD = $CMD" >> $LOGFILE
+            exit $ret
+         fi
+         echo "rebuild completed"
+         echo
 
+         if [[ $npat == *"1"* ]]; then
             ls $( echo "$EPAT*" | sed 's/%d/\*/' ) | while read -r line; do
                if [[ -e "$line".backup ]]; then
                   echo -n "Performing comparison against original file = \"""$line"".backup\"..."

--- a/erasureLib/erasureTest
+++ b/erasureLib/erasureTest
@@ -534,10 +534,10 @@ while [[ $cnt -lt $ITER ]]; do
             echo
             echo -e "\033[0;31mFAIL - output does not match expected data"
             echo -e "        compared $DATAFILE and $OUTFILE"
-            echo -e "CMD = ./libneTest read $EPAT $tN $e $start -s $FSZ -o $OUTFILE\033[0m"
+            echo -e "CMD = $CMD\033[0m"
             echo "   FAILURE: output of ne_read does not match the expected data" >> $LOGFILE
             echo "            compared $DATAFILE and $OUTFILE" >> $LOGFILE
-            echo "CMD = ./libneTest read $EPAT $tN $e $start -s $FSZ -o $OUTFILE" >> $LOGFILE
+            echo "CMD = $CMD" >> $LOGFILE
             exit -1
          fi
          echo "Comparison passed"

--- a/erasureLib/erasureTest
+++ b/erasureLib/erasureTest
@@ -322,12 +322,6 @@ while [[ $cnt -lt $ITER ]]; do
     
          nerr=$RANDOM
          let "nerr %= $(( e + 1 ))"
-         if [[ $nerr -eq 0 ]]; then
-            if [[ $dat_err_free -eq 1 ]]; then
-               nerr=$e
-            fi
-            dat_err_free=1
-         fi
 
          # only accept a stripe without errors if we have not already tried it
          if [[ $nerr -ne 0  ||  $nerr_met -ne 0 ]]; then

--- a/erasureLib/erasureTest
+++ b/erasureLib/erasureTest
@@ -257,7 +257,7 @@ while [[ $cnt -lt $ITER ]]; do
    dat_err_free=0
 
    echo
-   echo "Generating $n+$e striping starting at file $start..."
+   echo -e "\e[34mGenerating $n+$e striping starting at file $start...\e[0m"
    echo >> $LOGFILE
    echo >> $LIBTLOG
    echo "Generating $n+$e striping starting at file $start""..." >> $LOGFILE
@@ -281,7 +281,7 @@ while [[ $cnt -lt $ITER ]]; do
 
       if [[ $incnt -ne 0 ]]; then
          echo
-         echo "Continuing with the same $n+$e start position $start stripe..."
+         echo -e "\e[34mContinuing with the same $n+$e start position $start stripe...\e[0m"
          echo >> $LOGFILE
          echo "Continuring to use $n+$e striping with start $start..." >> $LOGFILE
          echo
@@ -445,17 +445,17 @@ while [[ $cnt -lt $ITER ]]; do
          if [[ ! $ret =~ $re  ||  $ret -gt $stat  ||  $ret -lt $tstat ]]; then
             # may still be possible to get false failure on silent zero-fill corruption
             echo
-            echo -e "\033[0;31mFAIL - read operation returned an inappropriate status, expected $stat but received $ret"
+            echo -e "\033[0;33mWARNING - read operation returned an inappropriate status, expected $stat but received $ret"
             echo -e "Minimum acceptible status value is $tstat"
+            echo -e "This may be the result of corruption of the meta crcsum value for an unused/partially used erasure block."
             echo -e "CMD = $CMD\033[0m"
-            echo "   FAILURE: read operation returned an inappropriate status, expected $stat but received $ret" >> $LOGFILE
+            echo "   WARNING: read operation returned an inappropriate status, expected $stat but received $ret" >> $LOGFILE
             echo "CMD = $CMD" >> $LOGFILE
-            exit -1
          elif [[ $ret -lt $stat ]]; then
             echo
-            echo -e "\033[0;33mNOTE - Read operation failed to detect all erasure errors (expected $stat but received $ret)."
-            echo -e "       This is not unusual, as the faulty erasure sections may not have been needed for data recovery."
-            echo -e "       CMD = $CMD\033[0m"
+            echo "NOTE - Read operation failed to detect all erasure errors (expected $stat but received $ret)."
+            echo "       This is not unusual, as the faulty erasure sections may not have been needed for data recovery."
+            echo "       CMD = $CMD"
             echo "   NOTE: read operation failed to detect all erasure errors, expected $stat but received $ret" >> $LOGFILE
             echo "CMD = $CMD" >> $LOGFILE
          fi
@@ -503,17 +503,17 @@ while [[ $cnt -lt $ITER ]]; do
          
          if [[ ! $ret =~ $re  ||  $ret -gt $stat  ||  $ret -lt $tstat ]]; then
             echo
-            echo -e "\033[0;31mFAIL - read operation returned an inappropriate status, expected $stat but received $ret"
+            echo -e "\033[0;33mWARNING - read operation returned an inappropriate status, expected $stat but received $ret"
             echo -e "Minimum acceptible status value is $tstat"
+            echo -e "This may be the result of corruption of the meta crcsum value for an unused/partially used erasure block."
             echo -e "CMD = $CMD\033[0m"
-            echo "   FAILURE: read operation returned an inappropriate status, expected $stat but received $ret" >> $LOGFILE
+            echo "   WARNING: read operation returned an inappropriate status, expected $stat but received $ret" >> $LOGFILE
             echo "CMD = $CMD" >> $LOGFILE
-            exit -1
          elif [[ $ret -lt $stat ]]; then
             echo
-            echo -e "\033[0;33mNOTE - Read operation failed to detect all erasure errors (expected $stat but received $ret)."
-            echo -e "       This is not unusual, as the faulty erasure sections may not have been needed for data recovery."
-            echo -e "       CMD = $CMD\033[0m"
+            echo "NOTE - Read operation failed to detect all erasure errors (expected $stat but received $ret)."
+            echo "       This is not unusual, as the faulty erasure sections may not have been needed for data recovery."
+            echo "       CMD = $CMD"
             echo "   NOTE: read operation failed to detect all erasure errors, expected $stat but received $ret" >> $LOGFILE
             echo "CMD = $CMD" >> $LOGFILE
          fi

--- a/erasureLib/erasureTest
+++ b/erasureLib/erasureTest
@@ -297,7 +297,8 @@ while [[ $cnt -lt $ITER ]]; do
             nerr=$e
          fi
          met_err_free=1
-      elif [[ $nerr -eq $(( n + e - 1 )) ]]; then
+      fi
+      if [[ $nerr -eq $(( n + e - 1 )) ]]; then
          # special case, we can't leave only a single valid meta file, as there is no guaratee we will get correct values then
          nerr=$(( nerr - 1 ))
       fi

--- a/erasureLib/erasureTest
+++ b/erasureLib/erasureTest
@@ -153,6 +153,7 @@ corrupt_file() {
       corrmegab=$(( ($corr / 1048576) + 1 ))
 
       cp $ftocorr $ftocorr".tmp"
+      iter=0
       diff=0
       while [[ $diff -eq 0 ]]; do
          # generate the random source inside this loop, so we get a different set of bytes each time
@@ -182,8 +183,13 @@ corrupt_file() {
          diff $ftocorr $ftocorr".tmp" > /dev/null 2>&1
          diff=$?
          if [[ $diff -eq 0 ]]; then
+            if [[ $iter -gt 4 ]]; then
+               echo "      too many corruption iterations, giving up now"
+               exit -1
+            fi
             echo "      corrption insertion did not alter file, retrying"
          fi
+         iter=$(( iter + 1 ))
       done
       rm $ftocorr".tmp"
       rm "$ftocorr".esource
@@ -293,6 +299,7 @@ while [[ $cnt -lt $ITER ]]; do
 
       stat=0
       tstat=0
+      dstat=0
 
       # Insert Meta Corruption
       nerr=$RANDOM
@@ -369,8 +376,11 @@ while [[ $cnt -lt $ITER ]]; do
             fi
             corrupt_file "$( echo "$EPAT" | sed 's/%d/'"$errpos"'/' )"
             # only note errors which do not align with meta errors and which are removal type or in data blocks
-            if [[ ${met_err_list[$errpos]} -eq 0  &&  ( $? -eq 0  ||  $truepos -lt $n ) ]]; then
-               tstat=$(( tstat + 2**errpos ))
+            if [[ $? -eq 0  ||  $truepos -lt $n ]]; then
+               dstat=$(( dstat + 2**errpos ))
+               if [[ ${met_err_list[$errpos]} -eq 0 ]]; then
+                  tstat=$(( tstat + 2**errpos ))
+               fi
             fi
          fi
       done
@@ -402,8 +412,10 @@ while [[ $cnt -lt $ITER ]]; do
       echo "The combined error pattern for this stripe is : $npat" >> $LOGFILE
       echo "The expected return code for complete error detection is $stat"
       echo "The expected return code for complete error detection is $stat" >> $LOGFILE
-      echo "The minimum acceptible error detection for reads is $tstat"
-      echo "The minimum acceptible error detection for reads is $tstat" >> $LOGFILE
+      echo "The minimum expected error detection for reads is $tstat"
+      echo "The minimum expected error detection for reads is $tstat" >> $LOGFILE
+      echo "The minimum acceptible error detection for reads is $dstat"
+      echo "The minimum acceptible error detection for reads is $dstat" >> $LOGFILE
       echo
       echo >> $LIBTLOG
 
@@ -442,19 +454,27 @@ while [[ $cnt -lt $ITER ]]; do
 
          { ret=$( time -p $CMD 2>&1 | tee -a $LIBTLOG | tail -n 1 | awk '{print $NF}' ); } 2>> $TLOGPREF$$.read
          
-         if [[ ! $ret =~ $re  ||  $ret -gt $stat  ||  $ret -lt $tstat ]]; then
+         if [[ ! $ret =~ $re  ||  $ret -gt $stat  ||  $ret -lt $dstat ]]; then
             # may still be possible to get false failure on silent zero-fill corruption
             echo
+            echo -e "\033[0;31mFAIL - read operation returned an inappropriate status, expected $stat but received $ret"
+            echo -e "Minimum expected status value is $tstat"".  Minimum acceptible value is $dstat."
+            echo -e "CMD = $CMD\033[0m"
+            echo "   FAILURE: read operation returned an inappropriate status, expected $stat but received $ret" >> $LOGFILE
+            echo "CMD = $CMD" >> $LOGFILE
+            exit -1
+         elif [[ $ret -lt $tstat ]]; then
             echo -e "\033[0;33mWARNING - read operation returned an inappropriate status, expected $stat but received $ret"
-            echo -e "Minimum acceptible status value is $tstat"
+            echo -e "The minimum acceptible status value is $dstat."
             echo -e "This may be the result of corruption of the meta crcsum value for an unused/partially used erasure block."
             echo -e "CMD = $CMD\033[0m"
             echo "   WARNING: read operation returned an inappropriate status, expected $stat but received $ret" >> $LOGFILE
             echo "CMD = $CMD" >> $LOGFILE
          elif [[ $ret -lt $stat ]]; then
             echo
-            echo "NOTE - Read operation failed to detect all erasure errors (expected $stat but received $ret)."
+            echo -e "\e[33mNOTE - \e[0mRead operation failed to detect all erasure errors (expected $stat but received $ret)."
             echo "       This is not unusual, as the faulty erasure sections may not have been needed for data recovery."
+            echo "       The minimum expected status value is $tstat."
             echo "       CMD = $CMD"
             echo "   NOTE: read operation failed to detect all erasure errors, expected $stat but received $ret" >> $LOGFILE
             echo "CMD = $CMD" >> $LOGFILE
@@ -511,7 +531,7 @@ while [[ $cnt -lt $ITER ]]; do
             echo "CMD = $CMD" >> $LOGFILE
          elif [[ $ret -lt $stat ]]; then
             echo
-            echo "NOTE - Read operation failed to detect all erasure errors (expected $stat but received $ret)."
+            echo -e "\e[33mNOTE - \e[0mRead operation failed to detect all erasure errors (expected $stat but received $ret)."
             echo "       This is not unusual, as the faulty erasure sections may not have been needed for data recovery."
             echo "       CMD = $CMD"
             echo "   NOTE: read operation failed to detect all erasure errors, expected $stat but received $ret" >> $LOGFILE

--- a/erasureLib/erasureTest
+++ b/erasureLib/erasureTest
@@ -151,20 +151,27 @@ corrupt_file() {
       echo "      inserting $corr random bytes at offset $offset" >> $LOGFILE
 
       corrmegab=$(( ($corr / 1048576) + 1 ))
-      dd if=/dev/urandom of="$ftocorr".esource bs=1M count=1 > /dev/null 2>&1
 
       cp $ftocorr $ftocorr".tmp"
       diff=0
       while [[ $diff -eq 0 ]]; do
+         # generate the random source inside this loop, so we get a different set of bytes each time
+         dd if=/dev/urandom of="$ftocorr".esource bs=1M count=1 > /dev/null 2>&1
+
+         # first, insert enough corruption to get to a MiB aligned offset
          corr_done=$(( 1048576 - (offset % 1048576) ))
+         # make sure not to insert too much though
          if [[ $corr_done -gt $corr ]]; then corr_done=$corr; fi
-         # insert enough to align our offset to megabyte boundaries
          dd if="$ftocorr".esource of=$ftocorr bs=1c count=$corr_done seek=$offset conv=notrunc > /dev/null 2>&1
+
+         # now insert the remaining corruption
          while [[ $corr_done -lt $corr ]]; do
+            # try to insert in 1MiB chunks at 1MiB aligned offsets
             tocorr=1
             corrbs="1M"
             toffset=$(( (offset + corr_done) / 1048576 ))
             if [[ $(( $corr_done + 1048576 )) -gt $corr ]]; then
+               # if we have less than 1MiB remaining, we'll have to do the insert one byte at a time
                tocorr=$(( corr - corr_done ))
                corrbs="1c"
                toffset=$(( offset + corr_done ))
@@ -183,8 +190,6 @@ corrupt_file() {
       echo "      creating backup of corrupted file"
       cp $ftocorr "$ftocorr".corrupted
    fi
-
-   echo "   file corruption complete"
 
    return $ctype
 
@@ -382,12 +387,6 @@ while [[ $cnt -lt $ITER ]]; do
       echo "Data error insertion complete, pattern is : $npat"
       echo "Data errors inserted, pattern is  $npat" >> $LOGFILE
 
-
-      echo "The minimum acceptible error detection for reads is $tstat"
-      echo "The minimum acceptible error detection for reads is $tstat" >> $LOGFILE
-      echo
-      echo >> $LIBTLOG
-
       # finally, get the total error pattern
       npat=""
       for pos in $(seq 0 $(( n + e - 1 )) ); do
@@ -398,6 +397,15 @@ while [[ $cnt -lt $ITER ]]; do
          fi
       done
 
+      echo
+      echo "The combined error pattern for this stripe is : $npat"
+      echo "The combined error pattern for this stripe is : $npat" >> $LOGFILE
+      echo "The expected return code for complete error detection is $stat"
+      echo "The expected return code for complete error detection is $stat" >> $LOGFILE
+      echo "The minimum acceptible error detection for reads is $tstat"
+      echo "The minimum acceptible error detection for reads is $tstat" >> $LOGFILE
+      echo
+      echo >> $LIBTLOG
 
 
       {

--- a/erasureLib/erasureTest
+++ b/erasureLib/erasureTest
@@ -70,6 +70,8 @@ FSZ=20  # Size of the input file in 10s of MBytes (i.e. a value of 20 -> 200M fi
 
 re='^[0-9]+$'
 
+
+
 if [[ $# -gt 0 ]]; then
    if [[ $1 =~ $re ]]; then
       ITER=$1
@@ -109,6 +111,86 @@ if [[ ! -e libneTest ]]; then
    exit 1
 fi
 
+
+# corruption insertion function
+corrupt_file() {
+   ftocorr="$1"
+   echo "   Corrupting file \"$ftocorr\"..."
+   echo "      creating backup of $ftocorr"
+   cp $ftocorr "$ftocorr".backup
+
+   ctype=$(( RANDOM % (3-ICRC) ))
+   if [[ $ctype -eq 0 ]]; then
+      echo "      corrupting file $ftocorr ( corruption-type : removal )"
+      echo "      corrupting file $ftocorr ( corruption-type : removal )" >> $LOGFILE
+      rm $ftocorr
+   elif [[ $ctype -eq 1 ]]; then
+      echo "      corrupting file $ftocorr ( corruption-type : truncate )"
+      echo "      corrupting file $ftocorr ( corruption-type : truncate )" >> $LOGFILE
+      fsize=$( stat $stfmt $ftocorr )
+      corr=$(( `od -N 4 -t uL -An /dev/urandom | awk '{print $1}'` % fsize ))
+      if [[ $(( fsize - corr )) -lt 2  &&  "$ftocorr" =~ .meta ]]; then
+         corr=$(( corr - 1 )) # meta files aren't affected by the loss of only the last byte
+      fi
+      echo "      truncating from $fsize to $corr bytes"
+      echo "      truncating from $fsize to $corr bytes" >> $LOGFILE
+      truncate -s $corr $ftocorr
+      echo "      creating backup of corrupted file"
+      cp $ftocorr "$ftocorr".corrupted
+   else
+      echo "      corrupting file $ftocorr ( corruption-type : silent )"
+      echo "      corrupting file $ftocorr ( corruption-type : silent )" >> $LOGFILE
+      fsize=$( stat $stfmt $ftocorr )
+      corr=$(( `od -N 4 -t uL -An /dev/urandom | awk '{print $1}'` % fsize ))
+      if [[ $corr -eq 0 ]]; then corr=1; fi # make sure we are actually inserting an error
+      offset=$(( `od -N 4 -t uL -An /dev/urandom | awk '{print $1}'` % ( fsize + 1 - corr ) ))
+      if [[ $corr -eq 1  &&  $offset -eq $(( fsize - 1 ))  &&  "$ftocorr" =~ .meta ]]; then
+         offset=$(( offset - 1 )) # meta files aren't affected by the loss of only the last byte
+      fi
+      echo "      inserting $corr random bytes at offset $offset"
+      echo "      inserting $corr random bytes at offset $offset" >> $LOGFILE
+
+      corrmegab=$(( ($corr / 1048576) + 1 ))
+      dd if=/dev/urandom of="$ftocorr".esource bs=1M count=1 > /dev/null 2>&1
+
+      cp $ftocorr $ftocorr".tmp"
+      diff=0
+      while [[ $diff -eq 0 ]]; do
+         corr_done=$(( 1048576 - (offset % 1048576) ))
+         if [[ $corr_done -gt $corr ]]; then corr_done=$corr; fi
+         # insert enough to align our offset to megabyte boundaries
+         dd if="$ftocorr".esource of=$ftocorr bs=1c count=$corr_done seek=$offset conv=notrunc > /dev/null 2>&1
+         while [[ $corr_done -lt $corr ]]; do
+            tocorr=1
+            corrbs="1M"
+            toffset=$(( (offset + corr_done) / 1048576 ))
+            if [[ $(( $corr_done + 1048576 )) -gt $corr ]]; then
+               tocorr=$(( corr - corr_done ))
+               corrbs="1c"
+               toffset=$(( offset + corr_done ))
+            fi
+            dd if="$ftocorr".esource of=$ftocorr bs=$corrbs count=$tocorr seek=$toffset conv=notrunc > /dev/null 2>&1
+            corr_done=$(( corr_done + 1048576 ))
+         done
+         diff $ftocorr $ftocorr".tmp" > /dev/null 2>&1
+         diff=$?
+         if [[ $diff -eq 0 ]]; then
+            echo "      corrption insertion did not alter file, retrying"
+         fi
+      done
+      rm $ftocorr".tmp"
+      rm "$ftocorr".esource
+      echo "      creating backup of corrupted file"
+      cp $ftocorr "$ftocorr".corrupted
+   fi
+
+   echo "   file corruption complete"
+
+   return $ctype
+
+}
+
+
 re=".* Active.*"
 
 ret=$( ./libneTest crc-status | tail -n 2 )
@@ -145,7 +227,7 @@ if [[ ! -e $WORK_DIRECTORY ]]; then
    echo "done"
 fi
 
-echo "Generating input file '$DATAFILE' (this will take some time)..."
+echo "Generating input file '$DATAFILE'..."
 dd if=/dev/urandom of=$DATAFILE bs=10485760 count=$FSZ
 echo "done"
 echo
@@ -166,20 +248,16 @@ while [[ $cnt -lt $ITER ]]; do
    start=$RANDOM
    let "start %= $(( n + e ))"
 
-   err_free=0
+   met_err_free=0
+   dat_err_free=0
 
    echo
    echo "Generating $n+$e striping starting at file $start..."
    echo >> $LOGFILE
    echo >> $LIBTLOG
    echo "Generating $n+$e striping starting at file $start""..." >> $LOGFILE
-#   tcnt=$( date +%s%N )
    { ret=$( time -p ./libneTest write -r $EPAT $n $e $start -s $FSZ -i $DATAFILE 2>&1 | tee -a $LIBTLOG | tail -n 1 | awk '{print $NF}' ); } 2>> $TLOGPREF$$.write
 
-#   tcnt="`date +%s%N` - $tcnt"
-#   if [[ $BC -eq 0 ]]; then
-#      tcnt=$( echo "$tcnt" | bc )
-#   fi
 
    if [[ ! $ret =~ $re  ||  $ret -ne 0 ]]; then
       echo -e "\033[0;31mFAIL - write operation returned an unexpected status"
@@ -188,9 +266,7 @@ while [[ $cnt -lt $ITER ]]; do
       echo "CMD = ./libneTest write -r $EPAT $n $e $start -s $FSZ -i $DATAFILE" >> $LOGFILE
       exit -1
    fi
-#   echo "...done.  Elapsed time = $tcnt""."
    echo "   stripe generation complete" >> $LOGFILE
-#   echo "$tcnt" >> $TLOGPREF$$.write
    echo
    ls $( echo "$EPAT" | sed 's/%d/\*/' )
    echo
@@ -206,178 +282,124 @@ while [[ $cnt -lt $ITER ]]; do
          echo
       fi
 
+      met_err_list=( 0 )
+      dat_err_list=( 0 )
+      silent_err_list=( 0 )
+
+      stat=0
+      tstat=0
+
+      # Insert Meta Corruption
       nerr=$RANDOM
       let "nerr %= $(( e + 1 ))"
-
       if [[ $nerr -eq 0 ]]; then
-         if [[ $err_free -eq 1 ]]; then
+         if [[ $met_err_free -eq 1 ]]; then
             nerr=$e
          fi
-         err_free=1
+         met_err_free=1
+      elif [[ $nerr -eq $(( n + e - 1 )) ]]; then
+         # special case, we can't leave only a single valid meta file, as there is no guaratee we will get correct values then
+         nerr=$(( nerr - 1 ))
       fi
+      errcnt=0
+
+      echo "$nerr meta error(s) are to be inserted..."
+      echo "Inserting $nerr meta error(s)..." >> $LOGFILE
+
+      while [[ $errcnt -lt $nerr ]]; do
+         errpos=$RANDOM
+         let "errpos %= $(( n + e ))"
+         if [[ ${met_err_list[$errpos]} -eq 0 ]]; then
+            # only corrupt the file if we are hitting a new postion
+            errcnt=$(( errcnt + 1 ))
+            met_err_list[$errpos]=1
+            stat=$(( stat + 2**errpos ))
+            tstat=$(( tstat + 2**errpos ))
+            corrupt_file "$( echo "$EPAT" | sed 's/%d/'"$errpos"'/' | sed 's/$/.meta/' )"
+         fi
+      done
 
       npat=""
-      maxpos=$(( n + e - nerr + 1 ))
-      oldpos=0
+      for pos in $(seq 0 $(( n + e - 1 )) ); do
+         if [[ ${met_err_list[$pos]} -eq 0  ]]; then
+            npat="$npat""0 "
+         else
+            npat="$npat""1 "
+         fi
+      done
+
+      echo "Meta error insertion complete, pattern is : $npat"
+      echo "Meta errors inserted, pattern is  $npat" >> $LOGFILE
+
+ 
+      # Insert Data Corruption
+      nerr=$RANDOM
+      let "nerr %= $(( e + 1 ))"
+      if [[ $nerr -eq 0 ]]; then
+         if [[ $dat_err_free -eq 1 ]]; then
+            nerr=$e
+         fi
+         dat_err_free=1
+      fi
       errcnt=0
-      errpos=-1
-      readerr=0 # read may not detect all errors
-      silent_count=0
 
-      echo "$nerr error(s) are to be inserted..."
-      echo "Inserting $nerr error(s)..." >> $LOGFILE
-      
-      {
+      echo "$nerr data error(s) are to be inserted..."
+      echo "Inserting $nerr data error(s)..." >> $LOGFILE
 
-         stat=0
-
-         while [[ $errcnt -lt $nerr ]]; do
-            while [[ $errpos -lt $oldpos ]]; do
-               errpos=$RANDOM
-               let "errpos %= maxpos"
-            done
-
-            echo "   placing error at $errpos""..."
-            echo "   placing error at $errpos""..." >> $LOGFILE
-            stat=$(( stat + 2**errpos ))
-
-            efile=$( echo "$EPAT" | sed 's/%d/'"$errpos"'/' )
-
-            echo "      creating backup of $efile""..."
-            cp $efile "$efile".backup
-
+      while [[ $errcnt -lt $nerr ]]; do
+         errpos=$RANDOM
+         let "errpos %= $(( n + e ))"
+         if [[ ${dat_err_list[$errpos]} -eq 0 ]]; then
+            # only corrupt the file if we are hitting a new postion
             truepos=$(( errpos - start ))
             if [[ $truepos -lt 0 ]]; then
                truepos=$(( truepos + n + e ))
             fi
-               
-            #if [[ $truepos -lt $n ]]; then
-            #   readerr=1
-            #fi
-
-            ctype=$(( RANDOM % (3-ICRC) ))
-            if [[ $ctype -eq 0 ]]; then
-               echo "      corrupting file $efile ( corruption-type : removal )"
-               echo "      corrupting file $efile ( corruption-type : removal )" >> $LOGFILE
-               rm $efile
-            elif [[ $ctype -eq 1 ]]; then
-               err_list[$silent_count]=$errpos
-               silent_count=$(( silent_count + 1 ))
-               echo "      corrupting file $efile ( corruption-type : truncate )"
-               echo "      corrupting file $efile ( corruption-type : truncate )" >> $LOGFILE
-               fsize=$( stat $stfmt $efile )
-               corr=$(( `od -N 4 -t uL -An /dev/urandom | awk '{print $1}'` % fsize ))
-               echo "      truncating from $fsize to $corr bytes"
-               echo "      truncating from $fsize to $corr bytes" >> $LOGFILE
-               #dd if=$efile of=$efile.tmp bs=1 count=$corr > /dev/null 2>&1
-               #rm $efile
-               #mv $efile.tmp $efile
-               truncate -s $corr $efile
-               echo "      creating backup of corrupted file"
-               cp $efile "$efile".corrupted
-            else
-               err_list[$silent_count]=$errpos
-               silent_count=$(( silent_count + 1 ))
-               echo "      corrupting file $efile ( corruption-type : silent )"
-               echo "      corrupting file $efile ( corruption-type : silent )" >> $LOGFILE
-               fsize=$( stat $stfmt $efile )
-               corr=$(( `od -N 4 -t uL -An /dev/urandom | awk '{print $1}'` % fsize ))
-               offset=$(( `od -N 4 -t uL -An /dev/urandom | awk '{print $1}'` % ( fsize - corr ) ))
-               echo "      inserting $corr random bytes at offset $offset"
-               echo "      inserting $corr random bytes at offset $offset" >> $LOGFILE
-
-               corrmegab=$(( ($corr / 1048576) + 1 ))
-               dd if=/dev/urandom of="$efile".esource bs=1M count=1 > /dev/null 2>&1
-
-               cp $efile $efile".tmp"
-               diff=0
-               while [[ $diff -eq 0 ]]; do
-                  corr_done=$(( 1048576 - (offset % 1048576) ))
-                  if [[ $corr_done -gt $corr ]]; then corr_done=$corr; fi
-                  # insert enough to align our offset to megabyte boundaries
-                  dd if="$efile".esource of=$efile bs=1c count=$corr_done seek=$offset conv=notrunc > /dev/null 2>&1
-                  while [[ $corr_done -lt $corr ]]; do
-                     tocorr=1
-                     corrbs="1M"
-                     toffset=$(( (offset + corr_done) / 1048576 ))
-                     if [[ $(( $corr_done + 1048576 )) -gt $corr ]]; then
-                        tocorr=$(( corr - corr_done ))
-                        corrbs="1c"
-                        toffset=$(( offset + corr_done ))
-                     fi
-                     dd if="$efile".esource of=$efile bs=$corrbs count=$tocorr seek=$toffset conv=notrunc > /dev/null 2>&1
-                     corr_done=$(( corr_done + 1048576 ))
-                  done
-                  diff $efile $efile".tmp" > /dev/null 2>&1
-                  diff=$?
-                  if [[ $diff -eq 0 ]]; then
-                     echo "      corrption insertion did not alter file, retrying"
-                  fi
-               done
-               rm $efile".tmp"
-               rm "$efile".esource
-               echo "      creating backup of corrupted file"
-               cp $efile "$efile".corrupted
-            fi
-
-            while [[ $oldpos -lt $errpos ]]; do
-               if [[ $npat == "" ]]; then
-                  npat="0"
-               else
-                  npat="$npat"".0"
-               fi
-               oldpos=$(( oldpos + 1 ))
-            done
-
-            if [[ $npat == "" ]]; then
-               npat="1"
-            else
-               npat="$npat"".1"
-            fi
-            echo "      error creation successful"
-            echo "      error creation successful" >> $LOGFILE
-            oldpos=$(( oldpos + 1 ))
-            
             errcnt=$(( errcnt + 1 ))
-            maxpos=$(( maxpos + 1 ))
-         done
-
-         maxpos=$(( maxpos - 1 ))
-
-         while [[ $oldpos -lt $maxpos ]]; do
-            if [[ $npat == "" ]]; then
-               npat="0"
-            else
-               npat="$npat"".0"
+            dat_err_list[$errpos]=1
+            # if there are no previous errors at this postion, note it for rc checking
+            if [[ ${met_err_list[$errpos]} -eq 0 ]]; then
+               stat=$(( stat + 2**errpos ))
             fi
-            oldpos=$(( oldpos + 1 ))
-         done
-
-         echo "Error insertion complete, pattern is : $npat"
-         echo "Errors inserted, pattern is  $npat" >> $LOGFILE
-         echo "There are $silent_count potentially silent errors in the stripe"
-         echo "There are $silent_count potentially silent errors in the stripe" >> $LOGFILE
-
-         tstat=$stat
-         tmp=0
-         while [[ $readerr -eq 0  &&  $tmp -lt $silent_count ]]; do
-            errpos=${err_list[$tmp]}
-            truepos=$(( errpos - start ))
-            if [[ $truepos -lt 0 ]]; then
-               truepos=$(( truepos + n + e ))
+            corrupt_file "$( echo "$EPAT" | sed 's/%d/'"$errpos"'/' )"
+            # only note errors which do not align with meta errors and which are removal type or in data blocks
+            if [[ ${met_err_list[$errpos]} -eq 0  &&  ( $? -eq 0  ||  $truepos -lt $n ) ]]; then
+               tstat=$(( tstat + 2**errpos ))
             fi
+         fi
+      done
 
-            if [[ ! $truepos -lt $n ]]; then
-               tstat=$(( tstat - (2**errpos) ))
-            fi
+      npat=""
+      for pos in $(seq 0 $(( n + e - 1 )) ); do
+         if [[ ${dat_err_list[$pos]} -eq 0 ]]; then
+            npat="$npat""0 "
+         else
+            npat="$npat""1 "
+         fi
+      done
 
-            tmp=$(( tmp + 1 ))
-         done
+      echo "Data error insertion complete, pattern is : $npat"
+      echo "Data errors inserted, pattern is  $npat" >> $LOGFILE
 
-         echo "The minimum acceptible error detection for reads is $tstat"
-         echo "The minimum acceptible error detection for reads is $tstat" >> $LOGFILE
-         echo
-         echo >> $LIBTLOG
+
+      echo "The minimum acceptible error detection for reads is $tstat"
+      echo "The minimum acceptible error detection for reads is $tstat" >> $LOGFILE
+      echo
+      echo >> $LIBTLOG
+
+      # finally, get the total error pattern
+      npat=""
+      for pos in $(seq 0 $(( n + e - 1 )) ); do
+         if [[ ${met_err_list[$pos]} -eq 0  &&  ${dat_err_list[$pos]} -eq 0 ]]; then
+            npat="$npat""0 "
+         else
+            npat="$npat""1 "
+         fi
+      done
+
+
+
+      {
 
          echo -n "Verifying corruption pattern (expecting pattern $stat)..."
          echo "Verifying corruption pattern (expecting pattern $stat)..." >> $LOGFILE

--- a/erasureLib/libneTest.c
+++ b/erasureLib/libneTest.c
@@ -562,11 +562,11 @@ int main( int argc, const char** argv )
       }
 
       if ( (tmp) ) {
-         PRINTout("Rebuild failed to correct all errors: errno=%d (%s)\n", tmp, errno, strerror(errno));
+         PRINTout("Rebuild failed to correct all errors: errno=%d (%s)\n", errno, strerror(errno));
          if ( tmp < 0 )
             PRINTout("libneTest: rebuild failed!\n" );
          else
-            PRINTout("libneTest: rebuild indicates only partial success\n" );
+            PRINTout("libneTest: rebuild indicates only partial success: rc = %d\n", tmp );
       }
       else
          PRINTout("libneTest: rebuild complete\n" );

--- a/erasureLib/libneTest.c
+++ b/erasureLib/libneTest.c
@@ -576,6 +576,7 @@ int main( int argc, const char** argv )
 
       if ( (show_state) ) {
          PRINTout( "Stripe state pre-rebuild:\n" ); 
+         PRINTout( "NOTE: the positions of these meta/data errors DO take stripe offset into account!\n" );
          print_erasure_state( state );
       }
 
@@ -643,6 +644,7 @@ int main( int argc, const char** argv )
          return -1;
       }
 
+      PRINTout( "NOTE: the positions of these meta/data errors DO NOT take stripe offset into account!\n" );
       print_erasure_state( state );
       // display the ne_stat return value
       PRINTout("stat rc: %d\n", ret);
@@ -811,8 +813,10 @@ int main( int argc, const char** argv )
    // close the handle and indicate it's close condition
    tmp = ne_close( handle );
 
-   if( (show_state) )
+   if( (show_state) ) {
+      PRINTout( "NOTE: the positions of these meta/data errors DO take stripe offset into account!\n" );
       print_erasure_state( state );
+   }
 
    PRINTout("close rc: %d\n",tmp);
 

--- a/erasureLib/libneTest.c
+++ b/erasureLib/libneTest.c
@@ -154,25 +154,45 @@ void usage(const char* prog_name, const char* op) {
    USAGE("help",       "");
    PRINTlog("\n");
 
-   if ( strncmp(op, "help", 10) ) // if help was not explicitly specified, avoid printing the entire usage block
+   if ( strncmp(op, "help", 5) ) // if help was not explicitly specified, avoid printing the entire usage block
       return;
 
+   PRINTlog("  Operations:\n");
+   PRINTlog("      read               Reads the content of the specified erasure stripe, utilizing erasure info only if necessary.\n");
+   PRINTlog("\n");
+   PRINTlog("      verify             Reads the content of the specified erasure stripe, including all erasure info.\n");
+   PRINTlog("\n");
+   PRINTlog("      write              Writes data to a new erasure stripe, overwriting any existing data.\n");
+   PRINTlog("\n");
+   PRINTlog("      rebuild            Reconstructs any damaged data/erasure blocks from valid blocks, if possible.\n");
+   PRINTlog("\n");
+   PRINTlog("      delete             Deletes all data, erasure, meta, and partial blocks of the given erasure stripe.  By default, \n");
+   PRINTlog("                          this operation prompts for confirmation before performing the deletion.\n");
+   PRINTlog("\n");
+   PRINTlog("      stat               Performs a sequential (ignoring stripe offset) read of meta information for the specified stripe \n");
+   PRINTlog("                          in order to determine N/E/O values.  Once these have been established, all remaining meta info \n");
+   PRINTlog("                          is read/verified and all data/erasure blocks are opened.  Stripe info and/or errors discovered \n");
+   PRINTlog("                          during this process are then displayed in a manner similar to that of '-e' option output for \n");
+   PRINTlog("                          for other commands (see NOTES for important output differences).\n");
+   PRINTlog("\n");
+   PRINTlog("      crc-status         Prints MAXN and MAXE values supported by libne, as well as whether intermediate crcs are active.\n");
+   PRINTlog("\n");
+   PRINTlog("      help               Prints this usage information and exits.\n");
+   PRINTlog("\n");
    PRINTlog("  Options:\n");
    PRINTlog("      -n                 For read/verfiy/write operations, specifies the use of the NE_NOINFO flag.\n");
-   PRINTlog("                         This will result in libne automatically determining values for N/E/start_file based on existing \n");
-   PRINTlog("                         stripe metadata.\n");
+   PRINTlog("                          This will result in the automatic setting of N/E/start_file values based on stripe metadata.\n");
    PRINTlog("\n");
    PRINTlog("      -t timing_flags    Specifies flags to be passed to the libne internal timer functions.  See 'NOTES' below.\n");
    PRINTlog("\n");
    PRINTlog("      -e                 For read/verify/write/rebuild, specifies the use of the NE_ESTATE flag.\n");
-   PRINTlog("                         This will allow an e_state struct to be retrieved following the operation.  Some of the contents \n");
-   PRINTlog("                         of the structure will be printed out to the console (N/E/O/bsz/totsz/meta_status/data_status).\n");
-   PRINTlog("                         See 'NOTES' for an explanation of some subtle differences between this output and that of 'stat'.\n");
+   PRINTlog("                          This will allow an e_state struct to be retrieved following the operation.  Some content of \n");
+   PRINTlog("                          the structure will be printed out to the console (N/E/O/bsz/totsz/meta_status/data_status).\n");
+   PRINTlog("                          See 'NOTES' for an explanation of subtle differences between this output and that of 'stat'.\n");
    PRINTlog("\n");
    PRINTlog("      -r                 Randomizes the read/write sizes used for data movement during the specified operation.\n");
    PRINTlog("\n");
-   PRINTlog("      -s input_size      Specifies the quantity of data to be read from the data source, whether that source be an \n");
-   PRINTlog("                         erasure stripe (for read/verify) or an input-file/zero-buffer (for write).\n");
+   PRINTlog("      -s input_size      Specifies the quantity of data to be read from the data source (stripe, file, or zero-buffer).\n");
    PRINTlog("\n");
    PRINTlog("      -o ontput_file     Specifies a standard POSIX file to which data retrieved from an erasure stripe should be stored.\n");
    PRINTlog("\n");
@@ -181,14 +201,13 @@ void usage(const char* prog_name, const char* op) {
    PRINTlog("      -f                 Used to perform a deletion without prompting for confirmation first.\n");
    PRINTlog("\n");
    PRINTlog("  NOTES:\n");
-   PRINTlog("     If an input file is not specified for write, a stream of zeros will be stored to the \n" \
-"      erasure stripe up to the given input_size.\n" );
+   PRINTlog("     If an input file is not specified for write, a stream of zeros will be stored to the erasure stripe up to the given \n");
+   PRINTlog("      input_size.  A failure to specify at least one of '-s' or '-i' for a write operation will result in an error.\n" );
    PRINTlog("\n");
-   PRINTlog("     The erasure state output produced by a 'stat' operation may differ slightly from that of \n");
-   PRINTlog("      '-e'.  The erasure structs returned by '-e' operations are adjusted by 'start_file' \n");
-   PRINTlog("      offset values, and thus indicate data/erasure status relative to the stripe format.\n");
-   PRINTlog("      The struct returned by ne_stat() has no such adjustment, and is thus relative to the \n");
-   PRINTlog("      actual file locations.\n");
+   PRINTlog("     The erasure state output produced by a 'stat' operation may differ slightly from that of '-e'.  The erasure structs \n");
+   PRINTlog("      returned by '-e' operations are adjusted by 'start_file' offset values, and thus indicate data/erasure status \n");
+   PRINTlog("      relative to the stripe format.\n");
+   PRINTlog("      The struct returned by ne_stat() has no such adjustment, and is thus relative to the actual file locations.\n");
    PRINTlog("      Return codes for all operations are relative to actual file locations (no erasure offset).\n");
    PRINTlog("\n");
    PRINTlog("     <stripe_width> refers to the total number of data/erasure parts in the target stripe (N+E).\n");


### PR DESCRIPTION
These commits include changes to harden libne against corruption of its '.meta' files as well as minor usability improvements to the accompanying utilities.  I have also tried to simplify some examples of overly complex logic in the code.
Finally, I have re-implemented the feature of rebuilds preserving original ownership for their reconstructed parts.