### PR TITLE
Very Minor Changes to Meta-Value/Under-Read Behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
-### # pattern "*", even when followed by "!*/", was hiding sockets/marfs_obj
-### *
-*.*
+*
 
-!*/
 !*.c
 !*.h
 !*.txt
@@ -11,6 +8,7 @@
 !*.conf
 !scripts/*
 !README*
+!sockets/mdal_obj
 
 *~
 *config.h

--- a/erasureLib/erasure.c
+++ b/erasureLib/erasure.c
@@ -1276,6 +1276,7 @@ if ( meta_buf->VAL >= MIN_VAL  &&  meta_buf->VAL <= MAX_VAL ) { \
    for ( i = 1; i < num_threads; i++ ) {
       // find the value with the most matches
       // For N/E: if two values are tied for matches, prefer the larger value (helps to avoid taking values from a single bad meta info)
+      // For Totsz : if two values are tied for matches, prefer the smaller value (helps to avoid returning zero-fill as 'data')
       // For other values: if two values are tied for matches, prefer the first
       if ( N_match[i] > N_match[N_index]  ||  
             ( N_match[i] == N_match[N_index]  &&  
@@ -1293,7 +1294,10 @@ if ( meta_buf->VAL >= MIN_VAL  &&  meta_buf->VAL <= MAX_VAL ) { \
          bsz_index = i;
       if ( nsz_match[i] > nsz_match[nsz_index] )
          nsz_index = i;
-      if ( totsz_match[i] > totsz_match[totsz_index] )
+      if ( totsz_match[i] > totsz_match[totsz_index]  ||  
+            ( totsz_match[i] == totsz_match[totsz_index]  &&
+              ((read_meta_buffer)(blocks[i].buffers[0]))->totsz < ((read_meta_buffer)(blocks[totsz_index].buffers[0]))->totsz )
+         )
          totsz_index = i;
    }
 

--- a/erasureLib/libneTest.c
+++ b/erasureLib/libneTest.c
@@ -329,6 +329,7 @@ void print_erasure_state( e_state state, int start_block ) {
 
 int main( int argc, const char** argv ) 
 {
+   errno = 0;  // init to zero (apparently not guaranteed)
    void* buff;
    unsigned long long totdone = 0;
 
@@ -758,7 +759,6 @@ int main( int argc, const char** argv )
 
    off_t bytes_moved = 0;
    while ( toread > 0 ) {
-
       // READ DATA
       ssize_t nread = toread; // assume success if no read takes place
       if ( (wr == 1)  &&  (std_fd) ) { // if input_file was defined, writes get data from it 


### PR DESCRIPTION
This is a trivial set of changes to the behavior of libne for determining totsz from meta info, to error reporting from libneTest in some circumstances, and to the gitignore.

Considering how minor these changes are, I will be immediately merging them in myself.  Overnight jenkins tests should immediately tell us if I've broken anything obvious.
