### PR TITLE
DAL: add new flags arg to verify functions

### DIFF
--- a/src/dal/dal.h
+++ b/src/dal/dal.h
@@ -121,6 +121,17 @@ void cpy_minfo( meta_info* target, meta_info* source );
  */
 int cmp_minfo( meta_info* minfo1, meta_info* minfo2 );
 
+// flags for DAL verify
+//  these flags should stay in sync with the flags in marfs/src/config/config.h
+//  so that the same flags value can be passed from the MarFS code to the
+//  libNE verify functions.
+enum {
+   CFG_FIX         = 0x1, // fix any problems found during verification
+   CFG_OWNERCHECK  = 0x2  // check that the owner of the security directory matches current user
+   // 0x4 used
+   // 0x8 used
+   // 0x10 used
+};
 
 typedef struct DAL_struct
 {
@@ -134,10 +145,10 @@ typedef struct DAL_struct
    size_t io_size;
 
    // DAL Functions --
-   int (*verify)(DAL_CTXT ctxt, char fix);
+   int (*verify)(DAL_CTXT ctxt, int flags);
    // Description:
    //  Ensure that the DAL is properly configured, functional, and secure.  Log any problems encountered.
-   //  If the 'fix' argument is non-zero, attempt to correct such problems.
+   //  If the 'flags' argument includes CFG_FIX, attempt to correct such problems.
    //  Note - the specifics of this implementaiton will depend GREATLY on the nature of the DAL.
    // Return Values:
    //  Zero on success, Non-zero if unresolved problems were found

--- a/src/dal/emergency_rebuild.c
+++ b/src/dal/emergency_rebuild.c
@@ -1172,7 +1172,7 @@ int main(int argc, char** argv) {
 
         // Create our data directory tree, along with rebuild symlinks and
         // rebuild directories
-        _posix_verify(dal->ctxt, 1, tgt, dist);
+        _posix_verify(dal->ctxt, CFG_FIX, tgt, dist);
 
         close(fd);
 

--- a/src/dal/fuzzing_dal.c
+++ b/src/dal/fuzzing_dal.c
@@ -245,7 +245,7 @@ void free_fuzz(FUZZING_DAL_CTXT dctxt)
 
 //   -------------    FUZZING IMPLEMENTATION    -------------
 
-int fuzzing_verify(DAL_CTXT ctxt, char fix)
+int fuzzing_verify(DAL_CTXT ctxt, int flags)
 {
    FUZZING_DAL_CTXT dctxt = (FUZZING_DAL_CTXT)ctxt;
 
@@ -255,7 +255,7 @@ int fuzzing_verify(DAL_CTXT ctxt, char fix)
       return -2;
    }
 
-   return dctxt->under_dal->verify(dctxt->under_dal->ctxt, fix);
+   return dctxt->under_dal->verify(dctxt->under_dal->ctxt, flags);
 }
 
 int fuzzing_migrate(DAL_CTXT ctxt, const char *objID, DAL_location src, DAL_location dest, char offline)

--- a/src/dal/noop_dal.c
+++ b/src/dal/noop_dal.c
@@ -188,7 +188,7 @@ int parse_size_node( ssize_t* target, xmlNode* node ) {
 
 //   -------------    NO-OP IMPLEMENTATION    -------------
 
-int noop_verify(DAL_CTXT ctxt, char fix)
+int noop_verify(DAL_CTXT ctxt, int flags)
 {
    if (ctxt == NULL)
    {

--- a/src/dal/rec_dal.c
+++ b/src/dal/rec_dal.c
@@ -315,7 +315,7 @@ ssize_t rec_get_meta_internal(BLOCK_CTXT ctxt, char *meta_buf, size_t size)
 
 //   -------------    REC IMPLEMENTATION    -------------
 
-int rec_verify(DAL_CTXT ctxt, char fix)
+int rec_verify(DAL_CTXT ctxt, int flags)
 {
   errno = ENOSYS;
   return -1;

--- a/src/dal/s3_dal.c
+++ b/src/dal/s3_dal.c
@@ -686,8 +686,10 @@ ssize_t s3_get_meta_internal(BLOCK_CTXT ctxt, char *meta_buf, size_t size)
 
 //   -------------    S3 IMPLEMENTATION    -------------
 
-int s3_verify(DAL_CTXT ctxt, char fix)
+int s3_verify(DAL_CTXT ctxt, int flags)
 {
+   int fix = flags & CFG_FIX;
+
    if (ctxt == NULL)
    {
       LOG(LOG_ERR, "received a NULL dal context!\n");

--- a/src/dal/timer_dal.c
+++ b/src/dal/timer_dal.c
@@ -499,7 +499,7 @@ void try_free_bctxt(TIMER_BLOCK_CTXT bctxt)
 
 //   -------------    TIMER IMPLEMENTATION    -------------
 
-int timer_verify(DAL_CTXT ctxt, char fix)
+int timer_verify(DAL_CTXT ctxt, int flags)
 {
   if (ctxt == NULL)
   {
@@ -513,7 +513,7 @@ int timer_verify(DAL_CTXT ctxt, char fix)
   struct timeval beg;
   gettimeofday(&beg, NULL);
 
-  int ret = dctxt->under_dal->verify(dctxt->under_dal->ctxt, fix);
+  int ret = dctxt->under_dal->verify(dctxt->under_dal->ctxt, flags);
 
   // get end time
   // get end time


### PR DESCRIPTION
This commit changes the DAL verify functions to take a flag argument instead of a single char value. The flags will allow passing multiple boolean parameters to the verify function.

In addition to the pre-existing fix paramter, this adds a new check owner parameter that determines whether the verify function should check the UID/GID of the secure root dir. This parameter will be false when starting MarFS, because MarFS can run under a different user than the directory owner, but will be true when verifying the config.